### PR TITLE
fix(LuckyIO): set default encoding on write

### DIFF
--- a/src/main/java/de/glueckscrew/gluecksroulette/io/LuckyIO.java
+++ b/src/main/java/de/glueckscrew/gluecksroulette/io/LuckyIO.java
@@ -20,7 +20,7 @@ public class LuckyIO {
 
     public static boolean write(File file, String data) {
         try (FileOutputStream fos = new FileOutputStream(file)) {
-            byte[] bytesArray = data.getBytes();
+            byte[] bytesArray = data.getBytes(ENCODING);
 
             fos.write(bytesArray);
             fos.flush();


### PR DESCRIPTION
Resolves: #48 

@Paul-Weisser please verify, whether it's now working on Windows. The tests are still green.